### PR TITLE
Scikit-learn copyright attribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ notice-rgx = "\\#\\ Authors:\\ The\\ scikit\\-learn\\ developers\\\r?\\\n\\#\\ S
 "doc/*"=["CPY001"]
 "build_tools/*"=["CPY001"]
 "xlearn/_build_utils/*"=["CPY001"]
+"xlearn/_jax/*"=["CPY001"]
 "maint_tools/*"=["CPY001"]
 ".spin/*"=["CPY001"]
 ".github/*"=["CPY001"]

--- a/xlearn/__check_build/__init__.py
+++ b/xlearn/__check_build/__init__.py
@@ -2,7 +2,7 @@
 compile jax-sklearn properly.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os

--- a/xlearn/__init__.py
+++ b/xlearn/__init__.py
@@ -1,6 +1,6 @@
 """Configure global settings and get information about the working environment."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Machine learning module for Python

--- a/xlearn/_build_utils/tempita.py
+++ b/xlearn/_build_utils/tempita.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import argparse

--- a/xlearn/_build_utils/version.py
+++ b/xlearn/_build_utils/version.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Extract version number from __init__.py"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os

--- a/xlearn/_config.py
+++ b/xlearn/_config.py
@@ -1,6 +1,6 @@
 """Global configuration state and functions for management"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os

--- a/xlearn/_distributor_init.py
+++ b/xlearn/_distributor_init.py
@@ -9,5 +9,5 @@ The jax-sklearn standard source distribution will not put code in this file,
 so you can safely replace this file with your own version.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/_loss/__init__.py
+++ b/xlearn/_loss/__init__.py
@@ -3,7 +3,7 @@ The :mod:`xlearn._loss` module includes loss function classes suitable for
 fitting classification and regression tasks.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .loss import (

--- a/xlearn/_loss/link.py
+++ b/xlearn/_loss/link.py
@@ -2,7 +2,7 @@
 Module contains classes for invertible (and differentiable) link functions.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from abc import ABC, abstractmethod

--- a/xlearn/_loss/loss.py
+++ b/xlearn/_loss/loss.py
@@ -6,7 +6,7 @@ Specific losses are used for regression, binary classification or multiclass
 classification.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Goals:

--- a/xlearn/_min_dependencies.py
+++ b/xlearn/_min_dependencies.py
@@ -1,6 +1,6 @@
 """All minimum dependencies for XLearn."""
 
-# Authors: The XLearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import argparse

--- a/xlearn/base.py
+++ b/xlearn/base.py
@@ -1,6 +1,6 @@
 """Base classes for all estimators and various utility functions."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy

--- a/xlearn/calibration.py
+++ b/xlearn/calibration.py
@@ -1,6 +1,6 @@
 """Methods for calibrating predicted probabilities."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/cluster/__init__.py
+++ b/xlearn/cluster/__init__.py
@@ -1,6 +1,6 @@
 """Popular unsupervised clustering algorithms."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._affinity_propagation import AffinityPropagation, affinity_propagation

--- a/xlearn/cluster/_affinity_propagation.py
+++ b/xlearn/cluster/_affinity_propagation.py
@@ -1,6 +1,6 @@
 """Affinity Propagation clustering algorithm."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/cluster/_agglomerative.py
+++ b/xlearn/cluster/_agglomerative.py
@@ -4,7 +4,7 @@ These routines perform some hierarchical agglomerative clustering of some
 input data.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/cluster/_bicluster.py
+++ b/xlearn/cluster/_bicluster.py
@@ -1,6 +1,6 @@
 """Spectral biclustering algorithms."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from abc import ABCMeta, abstractmethod

--- a/xlearn/cluster/_birch.py
+++ b/xlearn/cluster/_birch.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/cluster/_bisect_k_means.py
+++ b/xlearn/cluster/_bisect_k_means.py
@@ -1,6 +1,6 @@
 """Bisecting K-means clustering."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/cluster/_dbscan.py
+++ b/xlearn/cluster/_dbscan.py
@@ -2,7 +2,7 @@
 DBSCAN: Density-Based Spatial Clustering of Applications with Noise
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/cluster/_feature_agglomeration.py
+++ b/xlearn/cluster/_feature_agglomeration.py
@@ -3,7 +3,7 @@ Feature agglomeration. Base classes and functions for performing feature
 agglomeration.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/cluster/_hdbscan/__init__.py
+++ b/xlearn/cluster/_hdbscan/__init__.py
@@ -1,2 +1,2 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/cluster/_hdbscan/hdbscan.py
+++ b/xlearn/cluster/_hdbscan/hdbscan.py
@@ -3,7 +3,7 @@ HDBSCAN: Hierarchical Density-Based Spatial Clustering
          of Applications with Noise
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without

--- a/xlearn/cluster/_kmeans.py
+++ b/xlearn/cluster/_kmeans.py
@@ -1,6 +1,6 @@
 """K-means clustering."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/cluster/_mean_shift.py
+++ b/xlearn/cluster/_mean_shift.py
@@ -9,7 +9,7 @@ near-duplicates to form the final set of centroids.
 Seeding is performed using a binning technique for scalability.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/cluster/_optics.py
+++ b/xlearn/cluster/_optics.py
@@ -4,7 +4,7 @@ These routines execute the OPTICS algorithm, and implement various
 cluster extraction methods of the ordered list.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/cluster/_spectral.py
+++ b/xlearn/cluster/_spectral.py
@@ -1,6 +1,6 @@
 """Algorithms for spectral clustering"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/cluster/tests/test_hierarchical.py
+++ b/xlearn/cluster/tests/test_hierarchical.py
@@ -3,7 +3,7 @@ Several basic tests for hierarchical clustering procedures
 
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/cluster/tests/test_optics.py
+++ b/xlearn/cluster/tests/test_optics.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/compose/__init__.py
+++ b/xlearn/compose/__init__.py
@@ -5,7 +5,7 @@ refurbished versions of :class:`~xlearn.pipeline.Pipeline` and
 :class:`~xlearn.pipeline.FeatureUnion`.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._column_transformer import (

--- a/xlearn/compose/_column_transformer.py
+++ b/xlearn/compose/_column_transformer.py
@@ -4,7 +4,7 @@ to work with heterogeneous data and to apply different transformers to
 different columns.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/compose/_target.py
+++ b/xlearn/compose/_target.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/conftest.py
+++ b/xlearn/conftest.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import builtins

--- a/xlearn/covariance/__init__.py
+++ b/xlearn/covariance/__init__.py
@@ -5,7 +5,7 @@ precision matrix defined as the inverse of the covariance. Covariance estimation
 closely related to the theory of Gaussian graphical models.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._elliptic_envelope import EllipticEnvelope

--- a/xlearn/covariance/_elliptic_envelope.py
+++ b/xlearn/covariance/_elliptic_envelope.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Real

--- a/xlearn/covariance/_empirical_covariance.py
+++ b/xlearn/covariance/_empirical_covariance.py
@@ -3,7 +3,7 @@ Maximum likelihood covariance estimator.
 
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # avoid division truncation

--- a/xlearn/covariance/_graph_lasso.py
+++ b/xlearn/covariance/_graph_lasso.py
@@ -2,7 +2,7 @@
 estimator.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import operator

--- a/xlearn/covariance/_robust_covariance.py
+++ b/xlearn/covariance/_robust_covariance.py
@@ -5,7 +5,7 @@ Here are implemented estimators that are resistant to outliers.
 
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/covariance/_shrunk_covariance.py
+++ b/xlearn/covariance/_shrunk_covariance.py
@@ -6,7 +6,7 @@ shrunk_cov = (1-shrinkage)*cov + shrinkage*structured_estimate.
 
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # avoid division truncation

--- a/xlearn/covariance/tests/test_covariance.py
+++ b/xlearn/covariance/tests/test_covariance.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/covariance/tests/test_robust_covariance.py
+++ b/xlearn/covariance/tests/test_robust_covariance.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/cross_decomposition/__init__.py
+++ b/xlearn/cross_decomposition/__init__.py
@@ -1,6 +1,6 @@
 """Algorithms for cross decomposition."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._pls import CCA, PLSSVD, PLSCanonical, PLSRegression

--- a/xlearn/cross_decomposition/_pls.py
+++ b/xlearn/cross_decomposition/_pls.py
@@ -2,7 +2,7 @@
 The :mod:`xlearn.pls` module implements Partial Least Squares (PLS).
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/datasets/__init__.py
+++ b/xlearn/datasets/__init__.py
@@ -1,6 +1,6 @@
 """Utilities to load popular datasets and artificial data generators."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import textwrap

--- a/xlearn/datasets/_arff_parser.py
+++ b/xlearn/datasets/_arff_parser.py
@@ -1,6 +1,6 @@
 """Implementation of ARFF parsers: via LIAC-ARFF and pandas."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/datasets/_base.py
+++ b/xlearn/datasets/_base.py
@@ -2,7 +2,7 @@
 Base IO code for all datasets
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import csv

--- a/xlearn/datasets/_california_housing.py
+++ b/xlearn/datasets/_california_housing.py
@@ -19,7 +19,7 @@ Statistics and Probability Letters, 33:291-297, 1997.
 
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging

--- a/xlearn/datasets/_covtype.py
+++ b/xlearn/datasets/_covtype.py
@@ -10,7 +10,7 @@ The dataset page is available from UCI Machine Learning Repository
 Courtesy of Jock A. Blackard and Colorado State University.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging

--- a/xlearn/datasets/_kddcup99.py
+++ b/xlearn/datasets/_kddcup99.py
@@ -8,7 +8,7 @@ https://archive.ics.uci.edu/ml/machine-learning-databases/kddcup99-mld/kddcup.da
 
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import errno

--- a/xlearn/datasets/_lfw.py
+++ b/xlearn/datasets/_lfw.py
@@ -6,7 +6,7 @@ over the internet, all details are available on the official website:
     http://vis-www.cs.umass.edu/lfw/
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging

--- a/xlearn/datasets/_olivetti_faces.py
+++ b/xlearn/datasets/_olivetti_faces.py
@@ -10,7 +10,7 @@ web page of Sam Roweis:
     https://cs.nyu.edu/~roweis/
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real

--- a/xlearn/datasets/_openml.py
+++ b/xlearn/datasets/_openml.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import gzip

--- a/xlearn/datasets/_rcv1.py
+++ b/xlearn/datasets/_rcv1.py
@@ -5,7 +5,7 @@ The dataset page is available at
     http://jmlr.csail.mit.edu/papers/volume5/lewis04a/
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging

--- a/xlearn/datasets/_samples_generator.py
+++ b/xlearn/datasets/_samples_generator.py
@@ -2,7 +2,7 @@
 Generate samples of synthetic data sets.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import array

--- a/xlearn/datasets/_species_distributions.py
+++ b/xlearn/datasets/_species_distributions.py
@@ -25,7 +25,7 @@ References
 R. P. Anderson, R. E. Schapire - Ecological Modelling, 190:231-259, 2006.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging

--- a/xlearn/datasets/_svmlight_format_io.py
+++ b/xlearn/datasets/_svmlight_format_io.py
@@ -10,7 +10,7 @@ This format is used as the default format for both svmlight and the
 libsvm command line programs.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os.path

--- a/xlearn/datasets/_twenty_newsgroups.py
+++ b/xlearn/datasets/_twenty_newsgroups.py
@@ -22,7 +22,7 @@ test sets. The compressed dataset size is around 14 Mb compressed. Once
 uncompressed the train set is 52 MB and the test set is 34 MB.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import codecs

--- a/xlearn/datasets/data/__init__.py
+++ b/xlearn/datasets/data/__init__.py
@@ -1,2 +1,2 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/datasets/descr/__init__.py
+++ b/xlearn/datasets/descr/__init__.py
@@ -1,2 +1,2 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/datasets/images/__init__.py
+++ b/xlearn/datasets/images/__init__.py
@@ -1,2 +1,2 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/decomposition/__init__.py
+++ b/xlearn/decomposition/__init__.py
@@ -4,7 +4,7 @@ These include PCA, NMF, ICA, and more. Most of the algorithms of this module can
 regarded as dimensionality reduction techniques.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ..utils.extmath import randomized_svd

--- a/xlearn/decomposition/_base.py
+++ b/xlearn/decomposition/_base.py
@@ -1,6 +1,6 @@
 """Principal Component Analysis Base Classes"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from abc import ABCMeta, abstractmethod

--- a/xlearn/decomposition/_dict_learning.py
+++ b/xlearn/decomposition/_dict_learning.py
@@ -1,6 +1,6 @@
 """Dictionary learning."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/decomposition/_factor_analysis.py
+++ b/xlearn/decomposition/_factor_analysis.py
@@ -13,7 +13,7 @@ http://www.cs.ucl.ac.uk/staff/d.barber/brml,
 Algorithm 21.1
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/decomposition/_fastica.py
+++ b/xlearn/decomposition/_fastica.py
@@ -5,7 +5,7 @@ Reference: Tables 8.3 and 8.4 page 196 in the book:
 Independent Component Analysis, by  Hyvarinen et al.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/decomposition/_incremental_pca.py
+++ b/xlearn/decomposition/_incremental_pca.py
@@ -1,6 +1,6 @@
 """Incremental Principal Components Analysis."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral

--- a/xlearn/decomposition/_kernel_pca.py
+++ b/xlearn/decomposition/_kernel_pca.py
@@ -1,6 +1,6 @@
 """Kernel Principal Components Analysis."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real

--- a/xlearn/decomposition/_lda.py
+++ b/xlearn/decomposition/_lda.py
@@ -8,7 +8,7 @@ This implementation is modified from Matthew D. Hoffman's onlineldavb code
 Link: https://github.com/blei-lab/onlineldavb
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real

--- a/xlearn/decomposition/_nmf.py
+++ b/xlearn/decomposition/_nmf.py
@@ -1,6 +1,6 @@
 """Non-negative matrix factorization."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/decomposition/_pca.py
+++ b/xlearn/decomposition/_pca.py
@@ -1,6 +1,6 @@
 """Principal Component Analysis."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from math import lgamma, log, sqrt

--- a/xlearn/decomposition/_sparse_pca.py
+++ b/xlearn/decomposition/_sparse_pca.py
@@ -1,6 +1,6 @@
 """Matrix factorization with Sparse PCA."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real

--- a/xlearn/decomposition/_truncated_svd.py
+++ b/xlearn/decomposition/_truncated_svd.py
@@ -1,6 +1,6 @@
 """Truncated SVD for sparse matrices, aka latent semantic analysis (LSA)."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real

--- a/xlearn/decomposition/tests/test_factor_analysis.py
+++ b/xlearn/decomposition/tests/test_factor_analysis.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from itertools import combinations

--- a/xlearn/decomposition/tests/test_sparse_pca.py
+++ b/xlearn/decomposition/tests/test_sparse_pca.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/discriminant_analysis.py
+++ b/xlearn/discriminant_analysis.py
@@ -1,6 +1,6 @@
 """Linear and quadratic discriminant analysis."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/dummy.py
+++ b/xlearn/dummy.py
@@ -1,6 +1,6 @@
 """Dummy estimators that implement simple rules of thumb."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/ensemble/__init__.py
+++ b/xlearn/ensemble/__init__.py
@@ -1,6 +1,6 @@
 """Ensemble-based methods for classification, regression and anomaly detection."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._bagging import BaggingClassifier, BaggingRegressor

--- a/xlearn/ensemble/_bagging.py
+++ b/xlearn/ensemble/_bagging.py
@@ -1,6 +1,6 @@
 """Bagging meta-estimator."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/ensemble/_base.py
+++ b/xlearn/ensemble/_base.py
@@ -1,6 +1,6 @@
 """Base class for ensemble-based estimators."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from abc import ABCMeta, abstractmethod

--- a/xlearn/ensemble/_forest.py
+++ b/xlearn/ensemble/_forest.py
@@ -32,7 +32,7 @@ The module structure is the following:
 Single and multi-output problems are both handled.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import threading

--- a/xlearn/ensemble/_gb.py
+++ b/xlearn/ensemble/_gb.py
@@ -16,7 +16,7 @@ The module structure is the following:
   regression problems.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import math

--- a/xlearn/ensemble/_hist_gradient_boosting/__init__.py
+++ b/xlearn/ensemble/_hist_gradient_boosting/__init__.py
@@ -4,5 +4,5 @@ The implementation is a port from pygbm which is itself strongly inspired
 from LightGBM.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/ensemble/_hist_gradient_boosting/binning.py
+++ b/xlearn/ensemble/_hist_gradient_boosting/binning.py
@@ -6,7 +6,7 @@ Bin thresholds are computed with the quantiles so that each bin contains
 approximately the same number of samples.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/xlearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1,6 +1,6 @@
 """Fast Gradient Boosting decision trees for classification and regression."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/xlearn/ensemble/_hist_gradient_boosting/grower.py
@@ -5,7 +5,7 @@ TreeGrower builds a regression tree fitting a Newton-Raphson step, based on
 the gradients and hessians of the training data.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/ensemble/_hist_gradient_boosting/predictor.py
+++ b/xlearn/ensemble/_hist_gradient_boosting/predictor.py
@@ -2,7 +2,7 @@
 This module contains the TreePredictor class which is used for prediction.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/ensemble/_hist_gradient_boosting/utils.py
+++ b/xlearn/ensemble/_hist_gradient_boosting/utils.py
@@ -1,6 +1,6 @@
 """This module contains utility routines."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ...base import is_classifier

--- a/xlearn/ensemble/_iforest.py
+++ b/xlearn/ensemble/_iforest.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/ensemble/_stacking.py
+++ b/xlearn/ensemble/_stacking.py
@@ -1,6 +1,6 @@
 """Stacking classifier and regressor."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from abc import ABCMeta, abstractmethod

--- a/xlearn/ensemble/_voting.py
+++ b/xlearn/ensemble/_voting.py
@@ -6,7 +6,7 @@ This module contains:
  - A Voting regressor for regression estimators.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from abc import abstractmethod

--- a/xlearn/ensemble/_weight_boosting.py
+++ b/xlearn/ensemble/_weight_boosting.py
@@ -16,7 +16,7 @@ The module structure is the following:
   (AdaBoost.R2) for regression problems.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/ensemble/tests/test_bagging.py
+++ b/xlearn/ensemble/tests/test_bagging.py
@@ -2,7 +2,7 @@
 Testing for the bagging ensemble module (xlearn.ensemble.bagging).
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from itertools import cycle, product

--- a/xlearn/ensemble/tests/test_base.py
+++ b/xlearn/ensemble/tests/test_base.py
@@ -2,7 +2,7 @@
 Testing for the base module (xlearn.ensemble.base).
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections import OrderedDict

--- a/xlearn/ensemble/tests/test_forest.py
+++ b/xlearn/ensemble/tests/test_forest.py
@@ -2,7 +2,7 @@
 Testing for the forest module (xlearn.ensemble.forest).
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/ensemble/tests/test_iforest.py
+++ b/xlearn/ensemble/tests/test_iforest.py
@@ -2,7 +2,7 @@
 Testing for Isolation Forest algorithm (xlearn.ensemble.iforest).
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/ensemble/tests/test_stacking.py
+++ b/xlearn/ensemble/tests/test_stacking.py
@@ -1,6 +1,6 @@
 """Test the stacking classifier and regressor."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import re

--- a/xlearn/exceptions.py
+++ b/xlearn/exceptions.py
@@ -1,6 +1,6 @@
 """Custom warnings and errors used across jax-sklearn."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 __all__ = [

--- a/xlearn/experimental/__init__.py
+++ b/xlearn/experimental/__init__.py
@@ -6,5 +6,5 @@
     deprecation cycles. Use them at your own risks!
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/experimental/enable_halving_search_cv.py
+++ b/xlearn/experimental/enable_halving_search_cv.py
@@ -19,7 +19,7 @@ The ``# noqa`` comment comment can be removed: it just tells linters like
 flake8 to ignore the import, which appears as unused.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .. import model_selection

--- a/xlearn/experimental/enable_hist_gradient_boosting.py
+++ b/xlearn/experimental/enable_hist_gradient_boosting.py
@@ -7,7 +7,7 @@ It used to enable the use of
 normally from `xlearn.ensemble`.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Don't remove this file, we don't want to break users code just because the

--- a/xlearn/experimental/enable_iterative_imputer.py
+++ b/xlearn/experimental/enable_iterative_imputer.py
@@ -12,7 +12,7 @@ as an attribute of the impute module::
     >>> from xlearn.impute import IterativeImputer
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .. import impute

--- a/xlearn/feature_extraction/__init__.py
+++ b/xlearn/feature_extraction/__init__.py
@@ -1,6 +1,6 @@
 """Feature extraction from raw data."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from . import image, text

--- a/xlearn/feature_extraction/_dict_vectorizer.py
+++ b/xlearn/feature_extraction/_dict_vectorizer.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from array import array

--- a/xlearn/feature_extraction/_hash.py
+++ b/xlearn/feature_extraction/_hash.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from itertools import chain

--- a/xlearn/feature_extraction/_stop_words.py
+++ b/xlearn/feature_extraction/_stop_words.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # This list of English stop words is taken from the "Glasgow Information

--- a/xlearn/feature_extraction/image.py
+++ b/xlearn/feature_extraction/image.py
@@ -1,6 +1,6 @@
 """Utilities to extract features from images."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from itertools import product

--- a/xlearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/xlearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from random import Random

--- a/xlearn/feature_extraction/tests/test_image.py
+++ b/xlearn/feature_extraction/tests/test_image.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/feature_extraction/text.py
+++ b/xlearn/feature_extraction/text.py
@@ -1,6 +1,6 @@
 """Utilities to build feature vectors from text documents."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import array

--- a/xlearn/feature_selection/__init__.py
+++ b/xlearn/feature_selection/__init__.py
@@ -4,7 +4,7 @@ These include univariate filter selection methods and the recursive feature elim
 algorithm.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._base import SelectorMixin

--- a/xlearn/feature_selection/_base.py
+++ b/xlearn/feature_selection/_base.py
@@ -1,6 +1,6 @@
 """Generic feature selection mixin"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/feature_selection/_from_model.py
+++ b/xlearn/feature_selection/_from_model.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from copy import deepcopy

--- a/xlearn/feature_selection/_mutual_info.py
+++ b/xlearn/feature_selection/_mutual_info.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral

--- a/xlearn/feature_selection/_rfe.py
+++ b/xlearn/feature_selection/_rfe.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 """Recursive feature elimination for feature ranking"""

--- a/xlearn/feature_selection/_sequential.py
+++ b/xlearn/feature_selection/_sequential.py
@@ -2,7 +2,7 @@
 Sequential feature selection
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real

--- a/xlearn/feature_selection/_univariate_selection.py
+++ b/xlearn/feature_selection/_univariate_selection.py
@@ -1,6 +1,6 @@
 """Univariate features selection."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/feature_selection/_variance_threshold.py
+++ b/xlearn/feature_selection/_variance_threshold.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Real

--- a/xlearn/frozen/__init__.py
+++ b/xlearn/frozen/__init__.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._frozen import FrozenEstimator

--- a/xlearn/frozen/_frozen.py
+++ b/xlearn/frozen/_frozen.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from copy import deepcopy

--- a/xlearn/frozen/tests/test_frozen.py
+++ b/xlearn/frozen/tests/test_frozen.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import re

--- a/xlearn/gaussian_process/__init__.py
+++ b/xlearn/gaussian_process/__init__.py
@@ -1,6 +1,6 @@
 """Gaussian process based regression and classification."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from . import kernels

--- a/xlearn/gaussian_process/_gpc.py
+++ b/xlearn/gaussian_process/_gpc.py
@@ -1,6 +1,6 @@
 """Gaussian processes classification."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral

--- a/xlearn/gaussian_process/_gpr.py
+++ b/xlearn/gaussian_process/_gpr.py
@@ -1,6 +1,6 @@
 """Gaussian processes regression."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/gaussian_process/kernels.py
+++ b/xlearn/gaussian_process/kernels.py
@@ -15,7 +15,7 @@
 # optimization.
 
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Note: this module is strongly inspired by the kernel module of the george

--- a/xlearn/gaussian_process/tests/test_gpc.py
+++ b/xlearn/gaussian_process/tests/test_gpc.py
@@ -1,6 +1,6 @@
 """Testing for Gaussian process classification"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/gaussian_process/tests/test_gpr.py
+++ b/xlearn/gaussian_process/tests/test_gpr.py
@@ -1,6 +1,6 @@
 """Testing for Gaussian process regression"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import re

--- a/xlearn/gaussian_process/tests/test_kernels.py
+++ b/xlearn/gaussian_process/tests/test_kernels.py
@@ -1,6 +1,6 @@
 """Testing for kernels for Gaussian processes."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from inspect import signature

--- a/xlearn/impute/__init__.py
+++ b/xlearn/impute/__init__.py
@@ -1,6 +1,6 @@
 """Transformers for missing value imputation."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import typing

--- a/xlearn/impute/_base.py
+++ b/xlearn/impute/_base.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/impute/_iterative.py
+++ b/xlearn/impute/_iterative.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/impute/_knn.py
+++ b/xlearn/impute/_knn.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral

--- a/xlearn/inspection/__init__.py
+++ b/xlearn/inspection/__init__.py
@@ -1,6 +1,6 @@
 """Tools for model inspection."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._partial_dependence import partial_dependence

--- a/xlearn/inspection/_partial_dependence.py
+++ b/xlearn/inspection/_partial_dependence.py
@@ -1,6 +1,6 @@
 """Partial dependence plots for regression and classification models."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/inspection/_pd_utils.py
+++ b/xlearn/inspection/_pd_utils.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/inspection/_permutation_importance.py
+++ b/xlearn/inspection/_permutation_importance.py
@@ -1,6 +1,6 @@
 """Permutation importance for estimators."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/inspection/_plot/__init__.py
+++ b/xlearn/inspection/_plot/__init__.py
@@ -1,2 +1,2 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/inspection/_plot/decision_boundary.py
+++ b/xlearn/inspection/_plot/decision_boundary.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/inspection/_plot/partial_dependence.py
+++ b/xlearn/inspection/_plot/partial_dependence.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/isotonic.py
+++ b/xlearn/isotonic.py
@@ -1,6 +1,6 @@
 """Isotonic regression for obtaining monotonic fit to data."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import math

--- a/xlearn/kernel_approximation.py
+++ b/xlearn/kernel_approximation.py
@@ -1,6 +1,6 @@
 """Approximate kernel feature maps based on Fourier transforms and count sketches."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/kernel_ridge.py
+++ b/xlearn/kernel_ridge.py
@@ -1,6 +1,6 @@
 """Kernel ridge regression."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Real

--- a/xlearn/linear_model/__init__.py
+++ b/xlearn/linear_model/__init__.py
@@ -1,6 +1,6 @@
 """A variety of linear models."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # See http://jax-sklearn.sourceforge.net/modules/sgd.html and

--- a/xlearn/linear_model/_base.py
+++ b/xlearn/linear_model/_base.py
@@ -2,7 +2,7 @@
 Generalized Linear Models.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/linear_model/_bayes.py
+++ b/xlearn/linear_model/_bayes.py
@@ -2,7 +2,7 @@
 Various bayesian regression
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from math import log

--- a/xlearn/linear_model/_coordinate_descent.py
+++ b/xlearn/linear_model/_coordinate_descent.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/linear_model/_glm/__init__.py
+++ b/xlearn/linear_model/_glm/__init__.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .glm import (

--- a/xlearn/linear_model/_glm/_newton_solver.py
+++ b/xlearn/linear_model/_glm/_newton_solver.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 """

--- a/xlearn/linear_model/_glm/glm.py
+++ b/xlearn/linear_model/_glm/glm.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 """

--- a/xlearn/linear_model/_glm/tests/__init__.py
+++ b/xlearn/linear_model/_glm/tests/__init__.py
@@ -1,2 +1,2 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/linear_model/_glm/tests/test_glm.py
+++ b/xlearn/linear_model/_glm/tests/test_glm.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/linear_model/_huber.py
+++ b/xlearn/linear_model/_huber.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real

--- a/xlearn/linear_model/_least_angle.py
+++ b/xlearn/linear_model/_least_angle.py
@@ -3,7 +3,7 @@ Least Angle Regression algorithm. See the documentation on the
 Generalized Linear Model for a complete discussion.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import sys

--- a/xlearn/linear_model/_linear_loss.py
+++ b/xlearn/linear_model/_linear_loss.py
@@ -2,7 +2,7 @@
 Loss functions for linear models with raw_prediction = X @ coef
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/linear_model/_logistic.py
+++ b/xlearn/linear_model/_logistic.py
@@ -2,7 +2,7 @@
 Logistic Regression
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/linear_model/_omp.py
+++ b/xlearn/linear_model/_omp.py
@@ -1,6 +1,6 @@
 """Orthogonal matching pursuit algorithms"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/linear_model/_passive_aggressive.py
+++ b/xlearn/linear_model/_passive_aggressive.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Real

--- a/xlearn/linear_model/_perceptron.py
+++ b/xlearn/linear_model/_perceptron.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Real

--- a/xlearn/linear_model/_quantile.py
+++ b/xlearn/linear_model/_quantile.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/linear_model/_ransac.py
+++ b/xlearn/linear_model/_ransac.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/linear_model/_ridge.py
+++ b/xlearn/linear_model/_ridge.py
@@ -2,7 +2,7 @@
 Ridge regression
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/linear_model/_sag.py
+++ b/xlearn/linear_model/_sag.py
@@ -1,6 +1,6 @@
 """Solvers for Ridge and LogisticRegression using SAG algorithm"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/linear_model/_stochastic_gradient.py
+++ b/xlearn/linear_model/_stochastic_gradient.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 """Classification, regression and One-Class SVM using Stochastic Gradient

--- a/xlearn/linear_model/_theil_sen.py
+++ b/xlearn/linear_model/_theil_sen.py
@@ -2,7 +2,7 @@
 A Theil-Sen Estimator for Multiple Linear Regression Model
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/linear_model/tests/test_base.py
+++ b/xlearn/linear_model/tests/test_base.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/linear_model/tests/test_bayes.py
+++ b/xlearn/linear_model/tests/test_bayes.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from math import log

--- a/xlearn/linear_model/tests/test_coordinate_descent.py
+++ b/xlearn/linear_model/tests/test_coordinate_descent.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/linear_model/tests/test_huber.py
+++ b/xlearn/linear_model/tests/test_huber.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/linear_model/tests/test_omp.py
+++ b/xlearn/linear_model/tests/test_omp.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/linear_model/tests/test_quantile.py
+++ b/xlearn/linear_model/tests/test_quantile.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/linear_model/tests/test_sag.py
+++ b/xlearn/linear_model/tests/test_sag.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import math

--- a/xlearn/linear_model/tests/test_theil_sen.py
+++ b/xlearn/linear_model/tests/test_theil_sen.py
@@ -2,7 +2,7 @@
 Testing for Theil-Sen module (xlearn.linear_model.theil_sen)
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os

--- a/xlearn/manifold/__init__.py
+++ b/xlearn/manifold/__init__.py
@@ -1,6 +1,6 @@
 """Data embedding techniques."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._isomap import Isomap

--- a/xlearn/manifold/_isomap.py
+++ b/xlearn/manifold/_isomap.py
@@ -1,6 +1,6 @@
 """Isomap for manifold learning"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/manifold/_locally_linear.py
+++ b/xlearn/manifold/_locally_linear.py
@@ -1,6 +1,6 @@
 """Locally Linear Embedding"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real

--- a/xlearn/manifold/_mds.py
+++ b/xlearn/manifold/_mds.py
@@ -2,7 +2,7 @@
 Multi-dimensional Scaling (MDS).
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/manifold/_spectral_embedding.py
+++ b/xlearn/manifold/_spectral_embedding.py
@@ -1,6 +1,6 @@
 """Spectral Embedding."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/manifold/_t_sne.py
+++ b/xlearn/manifold/_t_sne.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # This is the exact and Barnes-Hut t-SNE implementation. There are other

--- a/xlearn/metrics/__init__.py
+++ b/xlearn/metrics/__init__.py
@@ -1,6 +1,6 @@
 """Score functions, performance metrics, pairwise metrics and distance computations."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from . import cluster

--- a/xlearn/metrics/_base.py
+++ b/xlearn/metrics/_base.py
@@ -3,7 +3,7 @@ Common code for all metrics.
 
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from itertools import combinations

--- a/xlearn/metrics/_classification.py
+++ b/xlearn/metrics/_classification.py
@@ -7,7 +7,7 @@ Function named as ``*_error`` or ``*_loss`` return a scalar value to minimize:
 the lower the better.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/metrics/_pairwise_distances_reduction/__init__.py
+++ b/xlearn/metrics/_pairwise_distances_reduction/__init__.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 #

--- a/xlearn/metrics/_pairwise_distances_reduction/_dispatcher.py
+++ b/xlearn/metrics/_pairwise_distances_reduction/_dispatcher.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from abc import abstractmethod

--- a/xlearn/metrics/_plot/__init__.py
+++ b/xlearn/metrics/_plot/__init__.py
@@ -1,2 +1,2 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/metrics/_plot/confusion_matrix.py
+++ b/xlearn/metrics/_plot/confusion_matrix.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from itertools import product

--- a/xlearn/metrics/_plot/det_curve.py
+++ b/xlearn/metrics/_plot/det_curve.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/metrics/_plot/precision_recall_curve.py
+++ b/xlearn/metrics/_plot/precision_recall_curve.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections import Counter

--- a/xlearn/metrics/_plot/regression.py
+++ b/xlearn/metrics/_plot/regression.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/metrics/_plot/roc_curve.py
+++ b/xlearn/metrics/_plot/roc_curve.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/metrics/_ranking.py
+++ b/xlearn/metrics/_ranking.py
@@ -7,7 +7,7 @@ Function named as ``*_error`` or ``*_loss`` return a scalar value to minimize:
 the lower the better.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/metrics/_regression.py
+++ b/xlearn/metrics/_regression.py
@@ -7,7 +7,7 @@ Function named as ``*_error`` or ``*_loss`` return a scalar value to minimize:
 the lower the better.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/metrics/_scorer.py
+++ b/xlearn/metrics/_scorer.py
@@ -13,7 +13,7 @@ is the model to be evaluated, ``X`` is the test data and ``y`` is the
 ground truth labeling (or ``None`` in the case of unsupervised models).
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy

--- a/xlearn/metrics/cluster/__init__.py
+++ b/xlearn/metrics/cluster/__init__.py
@@ -5,7 +5,7 @@
   model itself.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._bicluster import consensus_score

--- a/xlearn/metrics/cluster/_bicluster.py
+++ b/xlearn/metrics/cluster/_bicluster.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/metrics/cluster/_supervised.py
+++ b/xlearn/metrics/cluster/_supervised.py
@@ -4,7 +4,7 @@ Functions named as *_score return a scalar value to maximize: the higher the
 better.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/metrics/cluster/_unsupervised.py
+++ b/xlearn/metrics/cluster/_unsupervised.py
@@ -1,6 +1,6 @@
 """Unsupervised evaluation metrics."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools

--- a/xlearn/metrics/pairwise.py
+++ b/xlearn/metrics/pairwise.py
@@ -1,6 +1,6 @@
 """Metrics for pairwise distances and affinity of sets of samples."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/mixture/__init__.py
+++ b/xlearn/mixture/__init__.py
@@ -1,6 +1,6 @@
 """Mixture modeling algorithms."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._bayesian_mixture import BayesianGaussianMixture

--- a/xlearn/mixture/_base.py
+++ b/xlearn/mixture/_base.py
@@ -1,6 +1,6 @@
 """Base class for mixture models."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/mixture/_bayesian_mixture.py
+++ b/xlearn/mixture/_bayesian_mixture.py
@@ -1,6 +1,6 @@
 """Bayesian Gaussian Mixture Model."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import math

--- a/xlearn/mixture/_gaussian_mixture.py
+++ b/xlearn/mixture/_gaussian_mixture.py
@@ -1,6 +1,6 @@
 """Gaussian Mixture Model."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/mixture/tests/test_bayesian_mixture.py
+++ b/xlearn/mixture/tests/test_bayesian_mixture.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy

--- a/xlearn/mixture/tests/test_gaussian_mixture.py
+++ b/xlearn/mixture/tests/test_gaussian_mixture.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy

--- a/xlearn/mixture/tests/test_mixture.py
+++ b/xlearn/mixture/tests/test_mixture.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/model_selection/__init__.py
+++ b/xlearn/model_selection/__init__.py
@@ -1,6 +1,6 @@
 """Tools for model selection, such as cross validation and hyper-parameter tuning."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import typing

--- a/xlearn/model_selection/_classification_threshold.py
+++ b/xlearn/model_selection/_classification_threshold.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections.abc import MutableMapping

--- a/xlearn/model_selection/_plot.py
+++ b/xlearn/model_selection/_plot.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/model_selection/_search.py
+++ b/xlearn/model_selection/_search.py
@@ -3,7 +3,7 @@ The :mod:`xlearn.model_selection._search` includes utilities to fine-tune the
 parameters of an estimator.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/model_selection/_search_successive_halving.py
+++ b/xlearn/model_selection/_search_successive_halving.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from abc import abstractmethod

--- a/xlearn/model_selection/_split.py
+++ b/xlearn/model_selection/_split.py
@@ -3,7 +3,7 @@ The :mod:`xlearn.model_selection._split` module includes classes and
 functions to split the data based on a preset strategy.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/model_selection/_validation.py
+++ b/xlearn/model_selection/_validation.py
@@ -3,7 +3,7 @@ The :mod:`xlearn.model_selection._validation` module includes classes and
 functions to validate the model.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/multiclass.py
+++ b/xlearn/multiclass.py
@@ -25,7 +25,7 @@ for a given sample *will not* sum to unity, as they do in the single label
 case.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import array

--- a/xlearn/multioutput.py
+++ b/xlearn/multioutput.py
@@ -5,7 +5,7 @@ a base estimator to be provided in their constructor. The meta-estimator
 extends single output estimators to multioutput estimators.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/naive_bayes.py
+++ b/xlearn/naive_bayes.py
@@ -4,7 +4,7 @@ These are supervised learning methods based on applying Bayes' theorem with stro
 (naive) feature independence assumptions.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/neighbors/__init__.py
+++ b/xlearn/neighbors/__init__.py
@@ -1,6 +1,6 @@
 """The k-nearest neighbors algorithms."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._ball_tree import BallTree

--- a/xlearn/neighbors/_base.py
+++ b/xlearn/neighbors/_base.py
@@ -1,6 +1,6 @@
 """Base and mixin classes for nearest neighbors."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/neighbors/_classification.py
+++ b/xlearn/neighbors/_classification.py
@@ -1,6 +1,6 @@
 """Nearest Neighbor Classification"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/neighbors/_graph.py
+++ b/xlearn/neighbors/_graph.py
@@ -1,6 +1,6 @@
 """Nearest Neighbors graph functions"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/neighbors/_kde.py
+++ b/xlearn/neighbors/_kde.py
@@ -3,7 +3,7 @@ Kernel Density Estimation
 -------------------------
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/neighbors/_lof.py
+++ b/xlearn/neighbors/_lof.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/neighbors/_nca.py
+++ b/xlearn/neighbors/_nca.py
@@ -2,7 +2,7 @@
 Neighborhood Component Analysis
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import sys

--- a/xlearn/neighbors/_nearest_centroid.py
+++ b/xlearn/neighbors/_nearest_centroid.py
@@ -2,7 +2,7 @@
 Nearest Centroid Classification
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/neighbors/_regression.py
+++ b/xlearn/neighbors/_regression.py
@@ -1,6 +1,6 @@
 """Nearest Neighbor Regression."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/neighbors/_unsupervised.py
+++ b/xlearn/neighbors/_unsupervised.py
@@ -1,6 +1,6 @@
 """Unsupervised nearest neighbors learner"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ..base import _fit_context

--- a/xlearn/neighbors/tests/test_lof.py
+++ b/xlearn/neighbors/tests/test_lof.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import re

--- a/xlearn/neighbors/tests/test_nca.py
+++ b/xlearn/neighbors/tests/test_nca.py
@@ -2,7 +2,7 @@
 Testing for Neighborhood Component Analysis module (xlearn.neighbors.nca)
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import re

--- a/xlearn/neural_network/__init__.py
+++ b/xlearn/neural_network/__init__.py
@@ -1,6 +1,6 @@
 """Models based on neural networks."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._multilayer_perceptron import MLPClassifier, MLPRegressor

--- a/xlearn/neural_network/_base.py
+++ b/xlearn/neural_network/_base.py
@@ -1,6 +1,6 @@
 """Utilities for the neural network modules"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/neural_network/_multilayer_perceptron.py
+++ b/xlearn/neural_network/_multilayer_perceptron.py
@@ -1,6 +1,6 @@
 """Multi-layer Perceptron"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/neural_network/_rbm.py
+++ b/xlearn/neural_network/_rbm.py
@@ -1,6 +1,6 @@
 """Restricted Boltzmann Machine"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import time

--- a/xlearn/neural_network/_stochastic_optimizers.py
+++ b/xlearn/neural_network/_stochastic_optimizers.py
@@ -1,6 +1,6 @@
 """Stochastic optimization methods for MLP"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/neural_network/tests/test_mlp.py
+++ b/xlearn/neural_network/tests/test_mlp.py
@@ -2,7 +2,7 @@
 Testing for Multi-layer Perceptron module (xlearn.neural_network)
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import re

--- a/xlearn/pipeline.py
+++ b/xlearn/pipeline.py
@@ -1,6 +1,6 @@
 """Utilities to build a composite estimator as a chain of transforms and estimators."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/preprocessing/__init__.py
+++ b/xlearn/preprocessing/__init__.py
@@ -1,6 +1,6 @@
 """Methods for scaling, centering, normalization, binarization, and more."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._data import (

--- a/xlearn/preprocessing/_data.py
+++ b/xlearn/preprocessing/_data.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/preprocessing/_discretization.py
+++ b/xlearn/preprocessing/_discretization.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/preprocessing/_encoders.py
+++ b/xlearn/preprocessing/_encoders.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/preprocessing/_function_transformer.py
+++ b/xlearn/preprocessing/_function_transformer.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/preprocessing/_label.py
+++ b/xlearn/preprocessing/_label.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import array

--- a/xlearn/preprocessing/_polynomial.py
+++ b/xlearn/preprocessing/_polynomial.py
@@ -2,7 +2,7 @@
 This file contains preprocessing tools based on polynomials.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import collections

--- a/xlearn/preprocessing/_target_encoder.py
+++ b/xlearn/preprocessing/_target_encoder.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real

--- a/xlearn/preprocessing/tests/test_data.py
+++ b/xlearn/preprocessing/tests/test_data.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import re

--- a/xlearn/random_projection.py
+++ b/xlearn/random_projection.py
@@ -22,7 +22,7 @@ The main theoretical result behind the efficiency of random projection is the
   and can even be taken to be an orthogonal projection.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/semi_supervised/__init__.py
+++ b/xlearn/semi_supervised/__init__.py
@@ -4,7 +4,7 @@ These algorithms utilize small amounts of labeled data and large amounts of unla
 data for classification tasks.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._label_propagation import LabelPropagation, LabelSpreading

--- a/xlearn/semi_supervised/_label_propagation.py
+++ b/xlearn/semi_supervised/_label_propagation.py
@@ -52,7 +52,7 @@ Learning (2006), pp. 193-216
 Non-Parametric Function Induction in Semi-Supervised Learning. AISTAT 2005
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/semi_supervised/_self_training.py
+++ b/xlearn/semi_supervised/_self_training.py
@@ -25,7 +25,7 @@ from ..utils.validation import _estimator_has, check_is_fitted, validate_data
 
 __all__ = ["SelfTrainingClassifier"]
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/semi_supervised/tests/test_self_training.py
+++ b/xlearn/semi_supervised/tests/test_self_training.py
@@ -15,7 +15,7 @@ from xlearn.svm import SVC
 from xlearn.tests.test_pipeline import SimpleEstimator
 from xlearn.tree import DecisionTreeClassifier
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # load the iris dataset and randomly permute it

--- a/xlearn/svm/__init__.py
+++ b/xlearn/svm/__init__.py
@@ -3,7 +3,7 @@
 # See http://jax-sklearn.sourceforge.net/modules/svm.html for complete
 # documentation.
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._bounds import l1_min_c

--- a/xlearn/svm/_base.py
+++ b/xlearn/svm/_base.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/svm/_bounds.py
+++ b/xlearn/svm/_bounds.py
@@ -1,6 +1,6 @@
 """Determination of parameter bounds"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Real

--- a/xlearn/svm/_classes.py
+++ b/xlearn/svm/_classes.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real

--- a/xlearn/tests/test_base.py
+++ b/xlearn/tests/test_base.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pickle

--- a/xlearn/tests/test_calibration.py
+++ b/xlearn/tests/test_calibration.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/tests/test_check_build.py
+++ b/xlearn/tests/test_check_build.py
@@ -2,7 +2,7 @@
 Smoke Test the check_build module
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest

--- a/xlearn/tests/test_common.py
+++ b/xlearn/tests/test_common.py
@@ -2,7 +2,7 @@
 General tests for all estimators in xlearn.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os

--- a/xlearn/tests/test_docstring_parameters.py
+++ b/xlearn/tests/test_docstring_parameters.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import importlib

--- a/xlearn/tests/test_docstring_parameters_consistency.py
+++ b/xlearn/tests/test_docstring_parameters_consistency.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest

--- a/xlearn/tests/test_metadata_routing.py
+++ b/xlearn/tests/test_metadata_routing.py
@@ -2,7 +2,7 @@
 Metadata Routing Utility Tests
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import re

--- a/xlearn/tree/__init__.py
+++ b/xlearn/tree/__init__.py
@@ -1,6 +1,6 @@
 """Decision tree based models for classification and regression."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._classes import (

--- a/xlearn/tree/_classes.py
+++ b/xlearn/tree/_classes.py
@@ -3,7 +3,7 @@ This module gathers tree-based methods, including decision, regression and
 randomized trees. Single and multi-output problems are both handled.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy

--- a/xlearn/tree/_export.py
+++ b/xlearn/tree/_export.py
@@ -2,7 +2,7 @@
 This module defines export functions for decision trees.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections.abc import Iterable

--- a/xlearn/tree/_reingold_tilford.py
+++ b/xlearn/tree/_reingold_tilford.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/utils/__init__.py
+++ b/xlearn/utils/__init__.py
@@ -1,6 +1,6 @@
 """Various utilities to help with development."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ..exceptions import DataConversionWarning

--- a/xlearn/utils/_arpack.py
+++ b/xlearn/utils/_arpack.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .validation import check_random_state

--- a/xlearn/utils/_array_api.py
+++ b/xlearn/utils/_array_api.py
@@ -1,6 +1,6 @@
 """Tools to support array_api."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/utils/_available_if.py
+++ b/xlearn/utils/_available_if.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from functools import update_wrapper, wraps

--- a/xlearn/utils/_bunch.py
+++ b/xlearn/utils/_bunch.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/utils/_chunking.py
+++ b/xlearn/utils/_chunking.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/utils/_dataframe.py
+++ b/xlearn/utils/_dataframe.py
@@ -1,6 +1,6 @@
 """Functions to determine if an object is a dataframe or series."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import sys

--- a/xlearn/utils/_encode.py
+++ b/xlearn/utils/_encode.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections import Counter

--- a/xlearn/utils/_estimator_html_repr.py
+++ b/xlearn/utils/_estimator_html_repr.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/utils/_indexing.py
+++ b/xlearn/utils/_indexing.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers

--- a/xlearn/utils/_mask.py
+++ b/xlearn/utils/_mask.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from contextlib import suppress

--- a/xlearn/utils/_metadata_requests.py
+++ b/xlearn/utils/_metadata_requests.py
@@ -95,7 +95,7 @@ This mixin also implements the ``get_metadata_routing``, which meta-estimators
 need to override, but it works for simple consumers as is.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import inspect

--- a/xlearn/utils/_missing.py
+++ b/xlearn/utils/_missing.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import math

--- a/xlearn/utils/_mocking.py
+++ b/xlearn/utils/_mocking.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/utils/_optional_dependencies.py
+++ b/xlearn/utils/_optional_dependencies.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/utils/_param_validation.py
+++ b/xlearn/utils/_param_validation.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools

--- a/xlearn/utils/_plotting.py
+++ b/xlearn/utils/_plotting.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 import warnings
 from collections.abc import Mapping

--- a/xlearn/utils/_pprint.py
+++ b/xlearn/utils/_pprint.py
@@ -1,7 +1,7 @@
 """This module contains the _EstimatorPrettyPrinter class used in
 BaseEstimator.__repr__ for pretty-printing estimators"""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,

--- a/xlearn/utils/_repr_html/__init__.py
+++ b/xlearn/utils/_repr_html/__init__.py
@@ -1,2 +1,2 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/utils/_repr_html/base.py
+++ b/xlearn/utils/_repr_html/base.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/utils/_repr_html/estimator.py
+++ b/xlearn/utils/_repr_html/estimator.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import html

--- a/xlearn/utils/_repr_html/params.py
+++ b/xlearn/utils/_repr_html/params.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import html

--- a/xlearn/utils/_response.py
+++ b/xlearn/utils/_response.py
@@ -3,7 +3,7 @@
 It allows to make uniform checks and validation.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/utils/_set_output.py
+++ b/xlearn/utils/_set_output.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import importlib

--- a/xlearn/utils/_show_versions.py
+++ b/xlearn/utils/_show_versions.py
@@ -4,7 +4,7 @@ Utility methods to print system info for debugging
 adapted from :func:`pandas.show_versions`
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import platform

--- a/xlearn/utils/_tags.py
+++ b/xlearn/utils/_tags.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass, field
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/utils/_test_common/__init__.py
+++ b/xlearn/utils/_test_common/__init__.py
@@ -1,2 +1,2 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/xlearn/utils/_test_common/instance_generator.py
+++ b/xlearn/utils/_test_common/instance_generator.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/utils/_testing.py
+++ b/xlearn/utils/_testing.py
@@ -1,6 +1,6 @@
 """Testing utilities."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import atexit

--- a/xlearn/utils/_unique.py
+++ b/xlearn/utils/_unique.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/utils/_user_interface.py
+++ b/xlearn/utils/_user_interface.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import timeit

--- a/xlearn/utils/class_weight.py
+++ b/xlearn/utils/class_weight.py
@@ -1,6 +1,6 @@
 """Utilities for handling weights based on class labels."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/utils/deprecation.py
+++ b/xlearn/utils/deprecation.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools

--- a/xlearn/utils/discovery.py
+++ b/xlearn/utils/discovery.py
@@ -1,6 +1,6 @@
 """Utilities to discover jax-sklearn objects."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import inspect

--- a/xlearn/utils/estimator_checks.py
+++ b/xlearn/utils/estimator_checks.py
@@ -1,6 +1,6 @@
 """Various utilities to check the compatibility of estimators with jax-sklearn API."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 

--- a/xlearn/utils/extmath.py
+++ b/xlearn/utils/extmath.py
@@ -1,6 +1,6 @@
 """Utilities to perform optimal mathematical operations in jax-sklearn."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/utils/fixes.py
+++ b/xlearn/utils/fixes.py
@@ -4,7 +4,7 @@ If you add content to this file, please give the version of the package
 at which the fix is no longer needed.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import platform

--- a/xlearn/utils/graph.py
+++ b/xlearn/utils/graph.py
@@ -1,6 +1,6 @@
 """Graph utilities and algorithms."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/utils/metadata_routing.py
+++ b/xlearn/utils/metadata_routing.py
@@ -3,7 +3,7 @@
 # This module is not a separate sub-folder since that would result in a circular
 # import issue.
 #
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._metadata_requests import (  # noqa: F401

--- a/xlearn/utils/metaestimators.py
+++ b/xlearn/utils/metaestimators.py
@@ -1,6 +1,6 @@
 """Utilities for meta-estimators."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from abc import ABCMeta, abstractmethod

--- a/xlearn/utils/multiclass.py
+++ b/xlearn/utils/multiclass.py
@@ -1,6 +1,6 @@
 """Utilities to handle multiclass/multioutput target in classifiers."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings

--- a/xlearn/utils/optimize.py
+++ b/xlearn/utils/optimize.py
@@ -9,7 +9,7 @@ regression with large design matrix), this approach gives very
 significant speedups.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 # This is a modified file from scipy.optimize

--- a/xlearn/utils/parallel.py
+++ b/xlearn/utils/parallel.py
@@ -2,7 +2,7 @@
 usage.
 """
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools

--- a/xlearn/utils/random.py
+++ b/xlearn/utils/random.py
@@ -1,6 +1,6 @@
 """Utilities for random sampling."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import array

--- a/xlearn/utils/sparsefuncs.py
+++ b/xlearn/utils/sparsefuncs.py
@@ -1,6 +1,6 @@
 """A collection of utilities to work with sparse matrices and arrays."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/utils/stats.py
+++ b/xlearn/utils/stats.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ..utils._array_api import (

--- a/xlearn/utils/tests/test_deprecation.py
+++ b/xlearn/utils/tests/test_deprecation.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/xlearn/utils/tests/test_estimator_html_repr.py
+++ b/xlearn/utils/tests/test_estimator_html_repr.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import importlib

--- a/xlearn/utils/tests/test_extmath.py
+++ b/xlearn/utils/tests/test_extmath.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/xlearn/utils/tests/test_fixes.py
+++ b/xlearn/utils/tests/test_fixes.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/utils/tests/test_murmurhash.py
+++ b/xlearn/utils/tests/test_murmurhash.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/xlearn/utils/tests/test_seq_dataset.py
+++ b/xlearn/utils/tests/test_seq_dataset.py
@@ -1,4 +1,4 @@
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 from itertools import product

--- a/xlearn/utils/validation.py
+++ b/xlearn/utils/validation.py
@@ -1,6 +1,6 @@
 """Functions to validate input and parameters within jax-sklearn estimators."""
 
-# Authors: The jax-sklearn developers
+# Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numbers


### PR DESCRIPTION
#### Reference Issues/PRs


#### What does this implement/fix? Explain your changes.
This PR addresses file ownership and copyright attribution within the repository.

Specifically, it:
-   Corrects the copyright header in approximately 300 Python files from `# Authors: The jax-sklearn developers` to `# Authors: The scikit-learn developers`. This ensures proper attribution for code derived from scikit-learn, aligning with its BSD-3-Clause license.
-   Updates `pyproject.toml` to add `xlearn/_jax/*` to the `per-file-ignores` list for CPY001. Files in this directory are custom-developed and retain their original `# Authors: The JAX-xlearn developers` copyright.
-   Fixes the copyright header in `xlearn/_min_dependencies.py` to `# Authors: The scikit-learn developers`.

#### Any other comments?
All copyright checks pass after these changes (`ruff check --select=CPY001 xlearn/`).

---
<a href="https://cursor.com/background-agent?bcId=bc-5e9df4d0-fa74-486b-be7a-e595940e7fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e9df4d0-fa74-486b-be7a-e595940e7fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

